### PR TITLE
Remove redundant requires-python in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,4 @@ requires = [
   "setuptools_scm_git_archive >= 1.0",
   "wheel",
 ]
-requires-python = ">3.5"
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
PEP 518 introduced `pyproject.toml` as a configuration file for tools, like build systems, to use in the Python ecosystem. One of the primary motivations was to specify build-time dependencies separate from runtime dependencies, particularly for tools like `setuptools`.

Initially, the `build-system` table in `pyproject.toml` had a `requires-python` field, but it was later deemed redundant because the same information is typically specified in `setup.py` (or its equivalents when using other build backends). 

To avoid confusion and potential conflicts between these two sources of truth, the `requires-python` field in the `build-system` table of `pyproject.toml` was deprecated.